### PR TITLE
Fix memory leak

### DIFF
--- a/validator/sawtooth_validator/ffi.py
+++ b/validator/sawtooth_validator/ffi.py
@@ -66,24 +66,47 @@ LIBRARY.call("pylogger_init", LOGGER.getEffectiveLevel())
 PY_LIBRARY = Library(ctypes.PyDLL)
 
 
-def prepare_byte_result():
+def prepare_string_result():
     """Returns pair of byte pointer and size value for use as return parameters
     in a LIBRARY call
     """
-    return (ctypes.POINTER(ctypes.c_uint8)(), ctypes.c_size_t(0))
+    return (
+        ctypes.POINTER(ctypes.c_uint8)(),
+        ctypes.c_size_t(0),
+        ctypes.c_size_t(0),
+    )
 
 
-def from_c_bytes(c_data, c_data_len, reclaim=True):
-    """Takes a byte pointer and a length and converts it into a python bytes
-    value. The bytes are reclaimed using Rust FFI code if reclaim is True.
-    """
+def from_rust_string(string_ptr, string_len, string_cap):
     # pylint: disable=invalid-slice-index
-    py_bytes = bytes(c_data[:c_data_len.value])
-    if reclaim:
-        LIBRARY.call(
-            "ffi_reclaim_bytes",
-            ctypes.byref(c_data),
-            ctypes.byref(c_data_len))
+    py_bytes = bytes(string_ptr[:string_len.value])
+    LIBRARY.call(
+        "ffi_reclaim_string",
+        string_ptr,
+        string_len,
+        string_cap)
+    return py_bytes
+
+
+def prepare_vec_result():
+    """Returns pair of byte pointer and size value for use as return parameters
+    in a LIBRARY call
+    """
+    return (
+        ctypes.POINTER(ctypes.c_uint8)(),
+        ctypes.c_size_t(0),
+        ctypes.c_size_t(0),
+    )
+
+
+def from_rust_vec(vec_ptr, vec_len, vec_cap):
+    # pylint: disable=invalid-slice-index
+    py_bytes = bytes(vec_ptr[:vec_len.value])
+    LIBRARY.call(
+        "ffi_reclaim_vec",
+        vec_ptr,
+        vec_len,
+        vec_cap)
     return py_bytes
 
 

--- a/validator/sawtooth_validator/journal/block_manager.py
+++ b/validator/sawtooth_validator/journal/block_manager.py
@@ -155,18 +155,19 @@ class _BlockIterator:
         if not self._c_iter_ptr:
             raise StopIteration()
 
-        (c_result, c_result_len) = ffi.prepare_byte_result()
+        (vec_ptr, vec_len, vec_cap) = ffi.prepare_vec_result()
 
         _libexec("{}_next".format(self.name),
                  self._c_iter_ptr,
-                 ctypes.byref(c_result),
-                 ctypes.byref(c_result_len))
+                 ctypes.byref(vec_ptr),
+                 ctypes.byref(vec_len),
+                 ctypes.byref(vec_cap))
 
         # Check if NULL
-        if not c_result:
+        if not vec_ptr:
             raise StopIteration()
 
-        payload = ffi.from_c_bytes(c_result, c_result_len)
+        payload = ffi.from_rust_vec(vec_ptr, vec_len, vec_cap)
         block = Block()
         block.ParseFromString(payload)
 

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -123,18 +123,19 @@ class ChainController(OwnedPointer):
         return self.chain_head_fn()
 
     def chain_head_fn(self):
-        (c_result, c_result_len) = ffi.prepare_byte_result()
+        (vec_ptr, vec_len, vec_cap) = ffi.prepare_vec_result()
 
         _libexec('chain_controller_chain_head',
                  self.pointer,
-                 ctypes.byref(c_result),
-                 ctypes.byref(c_result_len))
+                 ctypes.byref(vec_ptr),
+                 ctypes.byref(vec_len),
+                 ctypes.byref(vec_cap))
 
         # Check if NULL
-        if not c_result:
+        if not vec_ptr:
             return None
 
-        payload = ffi.from_c_bytes(c_result, c_result_len)
+        payload = ffi.from_rust_vec(vec_ptr, vec_len, vec_cap)
         block = Block()
         block.ParseFromString(payload)
 

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -284,23 +284,27 @@ class BlockPublisher(OwnedPointer):
         self._py_call('initialize_block', ctypes.py_object(block))
 
     def summarize_block(self, force=False):
-        (c_result, c_result_len) = ffi.prepare_byte_result()
+        (vec_ptr, vec_len, vec_cap) = ffi.prepare_vec_result()
         self._call(
             'summarize_block',
             ctypes.c_bool(force),
-            ctypes.byref(c_result), ctypes.byref(c_result_len))
+            ctypes.byref(vec_ptr),
+            ctypes.byref(vec_len),
+            ctypes.byref(vec_cap))
 
-        return ffi.from_c_bytes(c_result, c_result_len)
+        return ffi.from_rust_vec(vec_ptr, vec_len, vec_cap)
 
     def finalize_block(self, consensus=None, force=False):
-        (c_result, c_result_len) = ffi.prepare_byte_result()
+        (vec_ptr, vec_len, vec_cap) = ffi.prepare_vec_result()
         self._call(
             'finalize_block',
             consensus, len(consensus),
             ctypes.c_bool(force),
-            ctypes.byref(c_result), ctypes.byref(c_result_len))
+            ctypes.byref(vec_ptr),
+            ctypes.byref(vec_len),
+            ctypes.byref(vec_cap))
 
-        return ffi.from_c_bytes(c_result, c_result_len).decode('utf-8')
+        return ffi.from_rust_vec(vec_ptr, vec_len, vec_cap).decode('utf-8')
 
     def cancel_block(self):
         self._call("cancel_block")

--- a/validator/src/ffi.rs
+++ b/validator/src/ffi.rs
@@ -16,8 +16,15 @@
  */
 
 #[no_mangle]
-pub extern "C" fn ffi_reclaim_bytes(bytes: *mut *const u8, bytes_len: *mut usize) -> isize {
-    unsafe { ::std::slice::from_raw_parts((*bytes) as *mut u8, *bytes_len) };
+pub extern "C" fn ffi_reclaim_string(s_ptr: *mut u8, s_len: usize, s_cap: usize) -> isize {
+    unsafe { String::from_raw_parts(s_ptr, s_len, s_cap) };
+
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn ffi_reclaim_vec(vec_ptr: *mut u8, vec_len: usize, vec_cap: usize) -> isize {
+    unsafe { Vec::from_raw_parts(vec_ptr, vec_len, vec_cap) };
 
     0
 }

--- a/validator/src/journal/block_manager_ffi.rs
+++ b/validator/src/journal/block_manager_ffi.rs
@@ -228,6 +228,7 @@ pub unsafe extern "C" fn block_manager_get_iterator_next(
     iterator: *mut c_void,
     block_bytes: *mut *const u8,
     block_len: *mut usize,
+    block_cap: *mut usize,
 ) -> ErrorCode {
     check_null!(iterator);
 
@@ -237,8 +238,9 @@ pub unsafe extern "C" fn block_manager_get_iterator_next(
             .write_to_bytes()
             .expect("Failed to serialize proto Block");
 
-        *block_len = bytes.as_slice().len();
-        *block_bytes = bytes.as_ptr();
+        *block_cap = bytes.capacity();
+        *block_len = bytes.len();
+        *block_bytes = bytes.as_slice().as_ptr();
 
         mem::forget(bytes);
 
@@ -277,6 +279,7 @@ pub unsafe extern "C" fn block_manager_branch_iterator_next(
     iterator: *mut c_void,
     block_bytes: *mut *const u8,
     block_len: *mut usize,
+    block_cap: *mut usize,
 ) -> ErrorCode {
     check_null!(iterator);
 
@@ -286,8 +289,9 @@ pub unsafe extern "C" fn block_manager_branch_iterator_next(
             .write_to_bytes()
             .expect("Failed to serialize proto Block");
 
-        *block_len = bytes.as_slice().len();
-        *block_bytes = bytes.as_ptr();
+        *block_cap = bytes.capacity();
+        *block_len = bytes.len();
+        *block_bytes = bytes.as_slice().as_ptr();
 
         mem::forget(bytes);
 
@@ -336,6 +340,7 @@ pub unsafe extern "C" fn block_manager_branch_diff_iterator_next(
     iterator: *mut c_void,
     block_bytes: *mut *const u8,
     block_len: *mut usize,
+    block_cap: *mut usize,
 ) -> ErrorCode {
     check_null!(iterator);
 
@@ -345,8 +350,9 @@ pub unsafe extern "C" fn block_manager_branch_diff_iterator_next(
             .write_to_bytes()
             .expect("Failed to serialize proto Block");
 
-        *block_len = bytes.as_slice().len();
-        *block_bytes = bytes.as_ptr();
+        *block_cap = bytes.capacity();
+        *block_len = bytes.len();
+        *block_bytes = bytes.as_slice().as_ptr();
 
         mem::forget(bytes);
 

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -271,6 +271,7 @@ pub unsafe extern "C" fn chain_controller_chain_head(
     chain_controller: *mut c_void,
     block: *mut *const u8,
     block_len: *mut usize,
+    block_cap: *mut usize,
 ) -> ErrorCode {
     check_null!(chain_controller);
 
@@ -279,8 +280,9 @@ pub unsafe extern "C" fn chain_controller_chain_head(
     if let Some(chain_head) = controller.chain_head().map(proto::block::Block::from) {
         match chain_head.write_to_bytes() {
             Ok(payload) => {
+                *block_cap = payload.capacity();
                 *block_len = payload.len();
-                *block = payload.as_ptr();
+                *block = payload.as_slice().as_ptr();
 
                 mem::forget(payload);
 


### PR DESCRIPTION
Using slice::from_raw_parts() does not reclaim ownership of the pointer, and so
when the slice goes out of scope, the memory is not freed. Because Rust is
picky about how you free Strings and Vecs, specifically that the capacity is
accurate, this change keeps Strings and Vecs as they are and passes around
pointers to them, rather than trying to convert them to something else. This
requires holding onto the capacity in addition to the length, but guarantees
that the capacity is correct when the struct is dropped.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>